### PR TITLE
Ensure Overflows do not occur when Composing the JWT Claim IAT and EXP

### DIFF
--- a/jwtgen.cpp
+++ b/jwtgen.cpp
@@ -148,6 +148,8 @@ JwtGenerator::Status JwtGenerator::getClaimBase64(
             olen, (const unsigned char*)claim, strlen(claim)) != 0) {
         // rc == MBEDTLS_ERR_BASE64_BUFFER_TOO_SMALL
         tr_error("Failed to encode claim into Base64. Buffer too small.");
+        // Delete the temporary memory area
+        delete claim;
         return ERROR_BUFFER_SIZE_NOT_ENOUGH;
     }
     // Delete the temporary memory area

--- a/jwtgen.h
+++ b/jwtgen.h
@@ -38,7 +38,7 @@ public:
      * 
      */
     static Status getJwt(char* buf, const size_t buf_len, size_t *olen, const char* private_key_pem,
-            const char* aud, time_t iat, time_t exp);
+            const char* aud, const time_t & iat, const time_t & exp);
 
 private:
     /* Gets key type from the given private key in PEM format.
@@ -74,7 +74,7 @@ private:
      * 
      * @note Project ID in Google Cloud IoT Core should be put into the Audience field.
      */
-    static Status getClaimBase64(char *buf, size_t buf_len, size_t *olen, const char* aud, time_t iat, time_t exp);
+    static Status getClaimBase64(char *buf, size_t buf_len, size_t *olen, const char* aud, const time_t & iat, const time_t & exp);
 
     /* Gets a signature part of JWT.
      *


### PR DESCRIPTION
[1] Ensure overflows do not occur when composing the JWT claim iat and exp.

[2] Also type-enforce that the JWT claim iat and exp, once input by the user, cannot be changed by accident.